### PR TITLE
fix cache viewer after dataview change

### DIFF
--- a/src/js/jagex2/io/Packet.ts
+++ b/src/js/jagex2/io/Packet.ts
@@ -65,7 +65,7 @@ export default class Packet extends Hashable {
         } else {
             this.data = src;
         }
-        this.view = new DataView(this.data.buffer);
+        this.view = new DataView(this.data.buffer, this.data.byteOffset, this.data.byteLength);
     }
 
     get length(): number {


### PR DESCRIPTION
Broke in https://github.com/2004scape/Client2/commit/c2abe2b40bc32c005a80999a8d506f20b702a835

Higher revision caches load again 😄 