### PR TITLE
emulate java getKeyChar() that reduces value if ctrl pressed

### DIFF
--- a/src/js/jagex2/client/GameShell.ts
+++ b/src/js/jagex2/client/GameShell.ts
@@ -356,6 +356,14 @@ export default abstract class GameShell {
         const code: number = mappedKey.code;
         let ch: number = mappedKey.ch;
 
+        if (e.ctrlKey) {
+            if (ch >= 65 && ch <= 90) {
+                ch -= 64;
+            } else if (ch >= 97 && ch <= 122) {
+                ch -= 96;
+            }
+        }
+
         if (ch < 30) {
             ch = 0;
         }

--- a/src/js/jagex2/client/GameShell.ts
+++ b/src/js/jagex2/client/GameShell.ts
@@ -357,7 +357,7 @@ export default abstract class GameShell {
         let ch: number = mappedKey.ch;
 
         if (e.ctrlKey) {
-            if (ch >= 'A'.charCodeAt(0) && ch <= 'Z'.charCodeAt(0)) {
+            if ((ch >= 'A'.charCodeAt(0) && ch <= ']'.charCodeAt(0)) || ch == '_'.charCodeAt(0)) {
                 ch -= 'A'.charCodeAt(0) - 1;
             } else if (ch >= 'a'.charCodeAt(0) && ch <= 'z'.charCodeAt(0)) {
                 ch -= 'a'.charCodeAt(0) - 1;

--- a/src/js/jagex2/client/GameShell.ts
+++ b/src/js/jagex2/client/GameShell.ts
@@ -357,10 +357,10 @@ export default abstract class GameShell {
         let ch: number = mappedKey.ch;
 
         if (e.ctrlKey) {
-            if (ch >= 65 && ch <= 90) {
-                ch -= 64;
-            } else if (ch >= 97 && ch <= 122) {
-                ch -= 96;
+            if (ch >= 'A'.charCodeAt(0) && ch <= 'Z'.charCodeAt(0)) {
+                ch -= 'A'.charCodeAt(0) - 1;
+            } else if (ch >= 'a'.charCodeAt(0) && ch <= 'z'.charCodeAt(0)) {
+                ch -= 'a'.charCodeAt(0) - 1;
             }
         }
 


### PR DESCRIPTION
fixes https://github.com/2004scape/Client2/issues/13

I don't think this needs to be added to onkeyup as the next line reduces the key value to 0

After this you'll be able to use ctrl shortcuts without them ending up in chat