### PR TITLE
fix: infinite await+infinite loop, now properly times out logins or logs off (arbitrary sleep value) and typos

### DIFF
--- a/src/js/game.ts
+++ b/src/js/game.ts
@@ -7816,7 +7816,7 @@ class Game extends Client {
         }
 
         if (count > this.npcCount) {
-            throw new Error(`eek! ${this.username} Too many npc!`);
+            throw new Error(`eek! ${this.username} Too many npcs`);
         }
 
         this.npcCount = 0;

--- a/src/js/game.ts
+++ b/src/js/game.ts
@@ -3438,7 +3438,7 @@ class Game extends Client {
                 this.pressedContinueOption = true;
             }
         } else if (action === 1773) {
-            // loc examine
+            // inv obj examine
             const obj: ObjType = ObjType.get(a);
             let examine: string;
 

--- a/src/js/jagex2/io/ClientStream.ts
+++ b/src/js/jagex2/io/ClientStream.ts
@@ -1,5 +1,6 @@
 import LinkList from '../datastruct/LinkList';
 import Linkable from '../datastruct/Linkable';
+import {sleep} from '../util/JsUtil';
 
 export type Socket = {
     host: string;
@@ -217,7 +218,7 @@ class WebSocketReader {
     private async readSlowByte(len: number): Promise<number> {
         this.event = this.queue.removeHead() as WebSocketEvent | null;
         while (this.total < len) {
-            await new Promise((resolve): ((value: PromiseLike<((data: WebSocketEvent | null) => void) | null>) => void) => (this.callback = resolve));
+            await Promise.race([new Promise((resolve): ((value: PromiseLike<((data: WebSocketEvent | null) => void) | null>) => void) => (this.callback = resolve)), sleep(500)]);
         }
         return this.event ? this.event.read : this.readSlowByte(len);
     }

--- a/src/js/jagex2/io/ClientStream.ts
+++ b/src/js/jagex2/io/ClientStream.ts
@@ -218,7 +218,12 @@ class WebSocketReader {
     private async readSlowByte(len: number): Promise<number> {
         this.event = this.queue.removeHead() as WebSocketEvent | null;
         while (this.total < len) {
-            await Promise.race([new Promise((resolve): ((value: PromiseLike<((data: WebSocketEvent | null) => void) | null>) => void) => (this.callback = resolve)), sleep(500)]);
+            await Promise.race([
+                new Promise((resolve): ((value: PromiseLike<((data: WebSocketEvent | null) => void) | null>) => void) => (this.callback = resolve)),
+                sleep(2000).then((): void => {
+                    throw new Error('WebSocketReader timed out or closed while reading.');
+                })
+            ]);
         }
         return this.event ? this.event.read : this.readSlowByte(len);
     }


### PR DESCRIPTION
`sleep()` fixed the infinite await, but had to throw an error to fix the infinite `readSlowByte` loop when connecting to an incompatible server like 317 prot.