### PR TITLE
fix: chance of out of bounds in model317

### DIFF
--- a/src/js/jagex2/graphics/Model.ts
+++ b/src/js/jagex2/graphics/Model.ts
@@ -1430,7 +1430,7 @@ export default class Model extends Hashable {
         }
 
         const axis: Packet = new Packet(meta.data);
-        axis.pos = meta.faceTextureAxisOffset * 6;
+        axis.pos = meta.faceTextureAxisOffset;
 
         for (let f: number = 0; f < texturedFaceCount; f++) {
             texturedVertexA[f] = axis.g2;


### PR DESCRIPTION
calling axis.g2 ***sometimes*** causes `RangeError: Offset is outside the bounds of the DataView at DataView.prototype.getUint16 (<anonymous>)`

317 client doesn't multiply by 6 here:
```java
        buf0.position = header.faceTextureAxisOffset;

        for (int face = 0; face < texturedFaceCount; face++) {
            texturedVertexA[face] = buf0.readU16();
            texturedVertexB[face] = buf0.readU16();
            texturedVertexC[face] = buf0.readU16();
        }
```