### PR TITLE
fix: always try loading world 0

### DIFF
--- a/src/js/configuration.ts
+++ b/src/js/configuration.ts
@@ -22,7 +22,7 @@ async function world(): Promise<void> {
     if (GameShell.getParameter('world').length === 0) {
         GameShell.setParameter('world', '1');
     }
-    if (window.location.hostname === 'localhost' && GameShell.getParameter('world') === '0') {
+    if (GameShell.getParameter('world') === '0') {
         localConfiguration();
     } else {
         await liveConfiguration(window.location.protocol.startsWith('https'));


### PR DESCRIPTION
Noticed that when 2004scape.org is down then you can't load the github pages link even with world set to 0 `https://2004scape.github.io/Client2/?world=0`.

I think it would be good to be able to load world 0 regardless. So you can use any world 0 webclient to connect to your localhost server without having to set it up yourself + it would be needed for a webworker server later on.